### PR TITLE
Add `toArray` method generation

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -134,6 +134,17 @@
               label="JSON response is an array"
             />
           </FormGroup>
+
+          <Label class="mt-2">
+            To Array
+          </Label>
+
+          <FormGroup>
+            <Checkbox
+              v-model="model.addToArrayMethod"
+              label="Add toArray method"
+            />
+          </FormGroup>
         </div>
       </div>
     </TabContent>

--- a/src/dto/Settings.ts
+++ b/src/dto/Settings.ts
@@ -32,6 +32,8 @@ export default interface Settings {
     addFromJsonMethod: boolean;
     jsonIsArray: boolean;
 
+    addToArrayMethod: boolean;
+
     docblock: PhpDocblock;
 
     namespace: string;
@@ -105,6 +107,8 @@ export const createDefaultSettings = (): Settings => {
 
         addFromJsonMethod: false,
         jsonIsArray: true,
+
+        addToArrayMethod: false,
 
         docblock: PhpDocblock.Necessary,
 

--- a/src/presenters/PhpClassPresenter.ts
+++ b/src/presenters/PhpClassPresenter.ts
@@ -9,6 +9,7 @@ import PhpClassFromJsonMethodPresenter from '@/presenters/PhpClassFromJsonMethod
 import PhpPropertyPresenter from '@/presenters/PhpPropertyPresenter';
 import PhpPropertyTypePresenter from '@/presenters/PhpPropertyTypePresenter';
 import CodeWriter from '@/writers/CodeWriter';
+import PhpClassToArrayMethodPresenter from '@/presenters/PhpClassToArrayMethodPresenter';
 
 export default class PhpClassPresenter {
     private readonly phpClass: PhpClass;
@@ -91,6 +92,12 @@ export default class PhpClassPresenter {
         if (this.settings.addFromJsonMethod) {
             codeWriter.insertNewLine();
             (new PhpClassFromJsonMethodPresenter(propertyTypePresenters, this.settings)).write(codeWriter);
+        }
+
+        // toArray method
+        if (this.settings.addToArrayMethod) {
+            codeWriter.insertNewLine();
+            (new PhpClassToArrayMethodPresenter(propertyTypePresenters)).write(codeWriter);
         }
 
         // close current class

--- a/src/presenters/PhpClassToArrayMethodPresenter.ts
+++ b/src/presenters/PhpClassToArrayMethodPresenter.ts
@@ -1,0 +1,103 @@
+import ArrayType from '@/php-types/ArrayType';
+import PhpPropertyTypePresenter from '@/presenters/PhpPropertyTypePresenter';
+import CodeWriter from '@/writers/CodeWriter';
+import {PhpVisibility} from '@/enums/PhpVisibility';
+import PhpClassType from '@/php-types/PhpClassType';
+
+export default class PhpClassToArrayMethodPresenter {
+    private readonly propertyTypePresenter: PhpPropertyTypePresenter[];
+
+    public constructor(propertyTypePresenter: PhpPropertyTypePresenter[]) {
+        this.propertyTypePresenter = propertyTypePresenter;
+    }
+
+    public write(codeWriter: CodeWriter): void {
+        const returnType = 'array';
+
+        // Add method docblock
+        const docblockLines = [
+            '@return array'
+        ];
+        
+        codeWriter.writeMultilineDocblock(docblockLines);
+
+        // Open method definition
+        codeWriter.openMethod(
+            PhpVisibility.Public,
+            'toArray',
+            returnType,
+            [],
+            {isStatic: false}
+        );
+
+        // Start generating array
+        codeWriter.writeLine('return [');
+        codeWriter.indent();
+
+        // Iterate through all properties
+        for (let i = 0; i < this.propertyTypePresenter.length; i++) {
+            const presenter = this.propertyTypePresenter[i];
+            const property = presenter.getProperty();
+            const propertyName = property.getName();
+            
+            const lines = this.getPropertyToArrayCode(presenter);
+            
+            // Add array key-value pair
+            if (lines.length === 1) {
+                codeWriter.writeLine(`'${propertyName}' => ${lines[0]}${i < this.propertyTypePresenter.length - 1 ? ',' : ''}`);
+            } else {
+                codeWriter.writeLine(`'${propertyName}' => ${lines[0]}`);
+                codeWriter.indent();
+                
+                for (let j = 1; j < lines.length - 1; j++) {
+                    codeWriter.writeLine(lines[j]);
+                }
+                
+                codeWriter.outdent();
+                codeWriter.writeLine(`${lines[lines.length - 1]}${i < this.propertyTypePresenter.length - 1 ? ',' : ''}`);
+            }
+        }
+
+        codeWriter.outdent();
+        codeWriter.writeLine('];');
+        codeWriter.closeMethod();
+    }
+
+    private getPropertyToArrayCode(typePresenter: PhpPropertyTypePresenter): string[] {
+        const property = typePresenter.getProperty();
+        const propertyAccess = `$this->${property.getName()}`;
+
+        // Handle array type properties
+        const classArrayType = property.getTypes()
+            .find(type => type instanceof ArrayType && type.isPhpClassArray()) as ArrayType | undefined;
+
+        if (classArrayType) {
+            if (property.isNullable()) {
+                return [
+                    `${propertyAccess} !== null ? array_map(function($item) {`,
+                    '    return $item->toArray();',
+                    `}, ${propertyAccess}) : null`
+                ];
+            }
+            
+            return [
+                'array_map(function($item) {',
+                '    return $item->toArray();',
+                `}, ${propertyAccess})`
+            ];
+        }
+
+        // Handle object type properties
+        const phpClass = property.getTypes().find(t => t instanceof PhpClassType) as PhpClassType | undefined;
+        
+        if (phpClass) {
+            if (property.isNullable()) {
+                return [`${propertyAccess} !== null ? ${propertyAccess}->toArray() : null`];
+            }
+            return [`${propertyAccess}->toArray()`];
+        }
+
+        // Handle primitive type properties
+        return [propertyAccess];
+    }
+} 

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public $stringArray;
+	/** @var (string|int|null)[] */
+	public $mixedArray;
+	public $nullArray;
+	public $unknownArray;
+	public $boolean;
+	public $float;
+	public $int;
+	public $null;
+	public $nestedClass;
+	public $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_3_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public $stringArray;
+	/** @var (string|int|null)[] */
+	public $mixedArray;
+	public $nullArray;
+	public $unknownArray;
+	public $boolean;
+	public $float;
+	public $int;
+	public $null;
+	public $nestedClass;
+	public $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_7_4_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_0_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_1_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_2_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,76 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->stringArray = $data->string_array;
+		$instance->mixedArray = $data->mixed_array;
+		$instance->nullArray = $data->null_array;
+		$instance->unknownArray = $data->unknown_array;
+		$instance->boolean = $data->boolean;
+		$instance->float = $data->float;
+		$instance->int = $data->int;
+		$instance->null = $data->null ?? null;
+		$instance->nestedClass = NestedClass::fromJson($data->nested_class);
+		$instance->string = $data->string;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->var = $data->var;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/all_types_json_php_8_3_with_to_array_method.txt
@@ -1,0 +1,53 @@
+<?php
+
+class RootObject
+{
+	/** @var string[] */
+	public array $stringArray;
+	/** @var (string|int|null)[] */
+	public array $mixedArray;
+	public array $nullArray;
+	public array $unknownArray;
+	public bool $boolean;
+	public float $float;
+	public int $int;
+	public null $null;
+	public NestedClass $nestedClass;
+	public string $string;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'string_array' => $this->string_array,
+			'mixed_array' => $this->mixed_array,
+			'null_array' => $this->null_array,
+			'unknown_array' => $this->unknown_array,
+			'boolean' => $this->boolean,
+			'float' => $this->float,
+			'int' => $this->int,
+			'null' => $this->null,
+			'nested_class' => $this->nested_class->toArray(),
+			'string' => $this->string
+		];
+	}
+}
+
+<?php
+
+class NestedClass
+{
+	public int $var;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'var' => $this->var
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public $alwaysPresent;
+	public $string;
+	public $object;
+	public $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public $test;
+	public $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_3_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public $alwaysPresent;
+	public $string;
+	public $object;
+	public $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public $test;
+	public $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_7_4_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_0_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_1_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_2_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,88 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->simpleNesting = array_map(static function($data) {
+			return SimpleNesting::fromJson($data);
+		}, $data->simple_nesting);
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->alwaysPresent = $data->always_present;
+		$instance->string = $data->string ?? null;
+		$instance->object = ($data->object ?? null) !== null ? Object::fromJson($data->object) : null;
+		$instance->number = $data->number ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test ?? null;
+		$instance->anotherTest = $data->another_test ?? null;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/merges_nested_arrays_php_8_3_with_to_array_method.txt
@@ -1,0 +1,61 @@
+<?php
+
+class RootObject
+{
+	/** @var SimpleNesting[] */
+	public array $simpleNesting;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'simple_nesting' => array_map(function($item) {
+				    return $item->toArray();
+			}, $this->simple_nesting)
+		];
+	}
+}
+
+<?php
+
+class SimpleNesting
+{
+	public float $alwaysPresent;
+	public ?string $string;
+	public ?Object $object;
+	public ?int $number;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'always_present' => $this->always_present,
+			'string' => $this->string,
+			'object' => $this->object !== null ? $this->object->toArray() : null,
+			'number' => $this->number
+		];
+	}
+}
+
+<?php
+
+class Object
+{
+	public ?int $test;
+	public ?int $anotherTest;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test,
+			'another_test' => $this->another_test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_3_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_7_4_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_0_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_1_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_2_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_from_json_and_to_array_methods.txt
@@ -1,0 +1,23 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	public static function fromJson(\stdClass $data): self
+	{
+		$instance = new self();
+		$instance->test = $data->test;
+		return $instance;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
+++ b/tests/converter/fixtures/results/simple_json_data_php_8_3_with_to_array_method.txt
@@ -1,0 +1,16 @@
+<?php
+
+class RootObject
+{
+	public int $test;
+
+	/**
+	 * @return array
+	 */
+	public function toArray(): array
+	{
+		return [
+			'test' => $this->test
+		];
+	}
+}

--- a/tests/converter/json-to-php-converter.spec.ts
+++ b/tests/converter/json-to-php-converter.spec.ts
@@ -612,6 +612,82 @@ const settingCases = versions.map((version) => {
                 declareStrictTypes: true,
             }
         ],
+        [
+            version + ' with toArray method',
+            {
+                phpVersion: version,
+
+                classCase: StringCase.PascalCase,
+                propertyCase: StringCase.CamelCase,
+
+                propertyVisibility: PhpVisibility.Public,
+                propertyDocblock: PhpDocblock.Necessary,
+                propertyDocblockType: PropertyDocblockType.Inline,
+                propertyAddExtraNewLine: false,
+                readonlyProperties: false,
+
+                addGetters: false,
+                getterCase: StringCase.CamelCase,
+                addSetters: false,
+                setterCase: StringCase.CamelCase,
+                isFluentSetter: false,
+
+                addConstructor: false,
+                constructorPropertyPromotion: false,
+
+                finalClasses: false,
+                readonlyClasses: false,
+                allPropertiesNullable: false,
+
+                addFromJsonMethod: false,
+                jsonIsArray: false,
+                addToArrayMethod: true,
+
+                docblock: PhpDocblock.Necessary,
+
+                rootClassName: 'RootObject',
+                namespace: '',
+                declareStrictTypes: false
+            }
+        ],
+        [
+            version + ' with fromJson and toArray methods',
+            {
+                phpVersion: version,
+
+                classCase: StringCase.PascalCase,
+                propertyCase: StringCase.CamelCase,
+
+                propertyVisibility: PhpVisibility.Public,
+                propertyDocblock: PhpDocblock.Necessary,
+                propertyDocblockType: PropertyDocblockType.Inline,
+                propertyAddExtraNewLine: false,
+                readonlyProperties: false,
+
+                addGetters: false,
+                getterCase: StringCase.CamelCase,
+                addSetters: false,
+                setterCase: StringCase.CamelCase,
+                isFluentSetter: false,
+
+                addConstructor: false,
+                constructorPropertyPromotion: false,
+
+                finalClasses: false,
+                readonlyClasses: false,
+                allPropertiesNullable: false,
+
+                addFromJsonMethod: true,
+                jsonIsArray: false,
+                addToArrayMethod: true,
+
+                docblock: PhpDocblock.Necessary,
+
+                rootClassName: 'RootObject',
+                namespace: '',
+                declareStrictTypes: false
+            }
+        ],
     ];
 
     return value;

--- a/tests/converter/json-to-php-converter.spec.ts
+++ b/tests/converter/json-to-php-converter.spec.ts
@@ -69,6 +69,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -106,6 +107,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -143,6 +145,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -180,6 +183,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -217,6 +221,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -254,6 +259,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -291,6 +297,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -328,6 +335,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -365,6 +373,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -402,6 +411,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -439,6 +449,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -476,6 +487,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -513,6 +525,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: true,
                 jsonIsArray: true,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.All,
 
@@ -551,6 +564,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 
@@ -589,6 +603,7 @@ const settingCases = versions.map((version) => {
 
                 addFromJsonMethod: false,
                 jsonIsArray: false,
+                addToArrayMethod: false,
 
                 docblock: PhpDocblock.Necessary,
 


### PR DESCRIPTION
- Add PhpClassToArrayMethodPresenter for generating `toArray` method
- Remove unnecessary hasReadonlyProperties check
- Clean up setter generation logic

The toArray method allows converting PHP objects back to arrays, which is a commonly requested feature for data transfer.

Refs #48